### PR TITLE
[feature/buffalo-base] Added company and organization models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ require (
 	github.com/gobuffalo/mw-paramlogger v1.0.0
 	github.com/gobuffalo/pop/v6 v6.0.4
 	github.com/gobuffalo/suite/v4 v4.0.2
+	github.com/gobuffalo/validate/v3 v3.3.1
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/markbates/grift v1.5.0
 	github.com/unrolled/secure v1.10.0
 )
@@ -38,8 +40,6 @@ require (
 	github.com/gobuffalo/nulls v0.4.1 // indirect
 	github.com/gobuffalo/plush/v4 v4.1.11 // indirect
 	github.com/gobuffalo/tags/v3 v3.1.2 // indirect
-	github.com/gobuffalo/validate/v3 v3.3.1 // indirect
-	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect

--- a/models/company.go
+++ b/models/company.go
@@ -1,0 +1,52 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
+)
+
+// Company is used by pop to map your companies database table to your go code.
+type Company struct {
+	ID            uuid.UUID      `json:"id" db:"id"`
+	Name          string         `json:"name" db:"name"`
+	CreatedAt     time.Time      `json:"created_at" db:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at" db:"updated_at"`
+	Organizations []Organization `json:"organizations,omitempty" has_many:"organizations"`
+}
+
+// String is not required by pop and may be deleted
+func (c Company) String() string {
+	jc, _ := json.Marshal(c)
+	return string(jc)
+}
+
+// Companies is not required by pop and may be deleted
+type Companies []Company
+
+// String is not required by pop and may be deleted
+func (c Companies) String() string {
+	jc, _ := json.Marshal(c)
+	return string(jc)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (c *Company) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (c *Company) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (c *Company) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/models/company_test.go
+++ b/models/company_test.go
@@ -1,0 +1,5 @@
+package models
+
+func (ms *ModelSuite) Test_Company() {
+	ms.Fail("This test needs to be implemented!")
+}

--- a/models/organization.go
+++ b/models/organization.go
@@ -1,0 +1,55 @@
+package models
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/gobuffalo/pop/v6"
+	"github.com/gobuffalo/validate/v3"
+	"github.com/gofrs/uuid"
+)
+
+// Organization is used by pop to map your organizations database table to your go code.
+type Organization struct {
+	ID               uuid.UUID `json:"id" db:"id"`
+	CompanyID        uuid.UUID `json:"-" db:"company_id"`
+	DisplayID        int       `json:"display_id" db:"display_id"`
+	Name             string    `json:"name" db:"name"`
+	ReportSendEmails string    `json:"report_send_emails" db:"report_send_emails"`
+	CreatedAt        time.Time `json:"created_at" db:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at" db:"updated_at"`
+	Company          *Company  `json:"company,omitempty" belongs_to:"company"`
+}
+
+// String is not required by pop and may be deleted
+func (o Organization) String() string {
+	jo, _ := json.Marshal(o)
+	return string(jo)
+}
+
+// Organizations is not required by pop and may be deleted
+type Organizations []Organization
+
+// String is not required by pop and may be deleted
+func (o Organizations) String() string {
+	jo, _ := json.Marshal(o)
+	return string(jo)
+}
+
+// Validate gets run every time you call a "pop.Validate*" (pop.ValidateAndSave, pop.ValidateAndCreate, pop.ValidateAndUpdate) method.
+// This method is not required and may be deleted.
+func (o *Organization) Validate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateCreate gets run every time you call "pop.ValidateAndCreate" method.
+// This method is not required and may be deleted.
+func (o *Organization) ValidateCreate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}
+
+// ValidateUpdate gets run every time you call "pop.ValidateAndUpdate" method.
+// This method is not required and may be deleted.
+func (o *Organization) ValidateUpdate(tx *pop.Connection) (*validate.Errors, error) {
+	return validate.NewErrors(), nil
+}

--- a/models/organization_test.go
+++ b/models/organization_test.go
@@ -1,0 +1,5 @@
+package models
+
+func (ms *ModelSuite) Test_Organization() {
+	ms.Fail("This test needs to be implemented!")
+}


### PR DESCRIPTION
## Backlog Issue
https://aiit-isa.backlog.jp/view/2022MO-xxx

## 対応した内容

migration ファイルはすでに作成されているので、スキップ (`-s` オプション) して model を生成した。

```
$ buffalo pop g model company -s
$ buffalo pop g model organization -s
```

- [x] comapny モデルの追加
- [x] organization モデルの追加

## 期待される結果
- [x] user auth の前に必要となる処理 (users の親であるため)
