### PR TITLE
[feature/2022MO-306] Added played_at to user_scenario_histories and score default value

### DIFF
--- a/migrations/20220626090222_create_scenario_quiz_options.up.fizz
+++ b/migrations/20220626090222_create_scenario_quiz_options.up.fizz
@@ -3,7 +3,7 @@ create_table("scenario_quiz_options") {
   t.Column("scenario_quiz_id", "uuid")
   t.Column("quiz_option_id", "uuid")
   t.Column("answer", "string", {"size": 255, "null": true})
-  t.Column("score", "integer")
+  t.Column("score", "integer", {"default": 0})
   t.Column("next_scenario_quiz_id", "uuid", {"null": true})
   t.Column("status", "integer")
   t.ForeignKey("scenario_quiz_id", {"scenario_quizzes": ["id"]}, {"on_delete": "cascade"})

--- a/migrations/20220626153916_create_user_scenario_histories.up.fizz
+++ b/migrations/20220626153916_create_user_scenario_histories.up.fizz
@@ -2,7 +2,8 @@ create_table("user_scenario_histories") {
   t.Column("id", "uuid", {primary: true, "default_raw": "gen_random_uuid()"})
   t.Column("user_id", "uuid")
   t.Column("scenario_id", "uuid")
-  t.Column("total_score", "integer")
+  t.Column("total_score", "integer", {"default": 0})
+  t.Column("played_at", "timestamp", {"null": true})
   t.ForeignKey("user_id", {"users": ["id"]}, {"on_delete": "cascade"})
   t.ForeignKey("scenario_id", {"scenarios": ["id"]}, {"on_delete": "cascade"})
 }

--- a/migrations/20220626154003_create_user_quiz_histories.up.fizz
+++ b/migrations/20220626154003_create_user_quiz_histories.up.fizz
@@ -5,7 +5,7 @@ create_table("user_quiz_histories") {
   t.Column("scenario_id", "uuid")
   t.Column("scenario_quiz_id", "uuid")
   t.Column("scenario_quiz_option_id", "uuid")
-  t.Column("score", "integer")
+  t.Column("score", "integer", {"default": 0})
   t.ForeignKey("user_scenario_history_id", {"user_scenario_histories": ["id"]}, {"on_delete": "cascade"})
   t.ForeignKey("user_id", {"users": ["id"]}, {"on_delete": "cascade"})
   t.ForeignKey("scenario_id", {"scenarios": ["id"]}, {"on_delete": "cascade"})

--- a/migrations/schema.sql
+++ b/migrations/schema.sql
@@ -105,7 +105,7 @@ CREATE TABLE public.scenario_quiz_options (
     scenario_quiz_id uuid NOT NULL,
     quiz_option_id uuid NOT NULL,
     answer character varying(255),
-    score integer NOT NULL,
+    score integer DEFAULT 0 NOT NULL,
     next_scenario_quiz_id uuid,
     status integer NOT NULL,
     created_at timestamp without time zone NOT NULL,
@@ -232,7 +232,7 @@ CREATE TABLE public.user_quiz_histories (
     scenario_id uuid NOT NULL,
     scenario_quiz_id uuid NOT NULL,
     scenario_quiz_option_id uuid NOT NULL,
-    score integer NOT NULL,
+    score integer DEFAULT 0 NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );
@@ -248,7 +248,8 @@ CREATE TABLE public.user_scenario_histories (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     user_id uuid NOT NULL,
     scenario_id uuid NOT NULL,
-    total_score integer NOT NULL,
+    total_score integer DEFAULT 0 NOT NULL,
+    played_at timestamp without time zone,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL
 );


### PR DESCRIPTION
## Backlog Issue
https://aiit-isa.backlog.jp/view/2022MO-306

## 対応した内容
- [x] user_scenario_histories に played_at を追加 (nullable)
- [x] score のデフォルト値を 0 にした (not null)


## 期待される結果
- [x] played_at が null の場合はシナリオを中断したこととみなすことができる
