### PR TITLE
[feature/2022MO-339] Added DisplayID to SetCurrentUser

### DIFF
--- a/actions/users.go
+++ b/actions/users.go
@@ -56,11 +56,15 @@ func SetCurrentUser(next buffalo.Handler) buffalo.Handler {
 	return func(c buffalo.Context) error {
 		if uid := c.Session().Get("current_user_id"); uid != nil {
 			u := &models.User{}
+			o := &models.Organization{}
 			tx := c.Value("tx").(*pop.Connection)
-			err := tx.Find(u, uid)
-			if err != nil {
+			if err := tx.Find(u, uid); err != nil {
 				return errors.WithStack(err)
 			}
+			if err := tx.Find(o, u.OrganizationID); err != nil {
+				return errors.WithStack(err)
+			}
+			u.DisplayID = o.DisplayID
 			c.Set("current_user", u)
 		}
 		return next(c)


### PR DESCRIPTION
## Backlog Issue
https://aiit-isa.backlog.jp/view/2022MO-339

## 対応した内容
- [x] SetCurrentUser() の処理に Organization.DisplayID を追加した。


## 期待される結果
- [x] ログイン後 Global Navigation の組織 ID が反映されるようになる。
